### PR TITLE
Add audio seeking support with a slider

### DIFF
--- a/hibikase/AudioFile.h
+++ b/hibikase/AudioFile.h
@@ -14,6 +14,7 @@
 #pragma once
 
 #include <memory>
+#include <chrono>
 
 #include <QAudioFormat>
 #include <QByteArray>
@@ -30,6 +31,12 @@ public:
     QBuffer *GetPCMBuffer() const
     {
         return m_pcm_buffer.get();
+    }
+    std::chrono::microseconds GetDuration() const
+    {
+        if (!m_pcm_buffer)
+            return std::chrono::milliseconds::zero();
+        return std::chrono::microseconds(m_pcm_format.durationForBytes(m_pcm_buffer->size()));
     }
 private:
     enum AudioType {

--- a/hibikase/LineTimingDecorations.cpp
+++ b/hibikase/LineTimingDecorations.cpp
@@ -177,7 +177,7 @@ LineTimingDecorations::LineTimingDecorations(KaraokeData::Line* line, int positi
     }
 }
 
-void LineTimingDecorations::Update(std::chrono::milliseconds time)
+void LineTimingDecorations::Update(Milliseconds time)
 {
     const TimingState state = GetTimingState(time, m_line->GetStart(), m_line->GetEnd());
     if (state == m_state && state != TimingState::Playing)

--- a/hibikase/PlaybackWidget.h
+++ b/hibikase/PlaybackWidget.h
@@ -21,6 +21,7 @@
 #include <QIODevice>
 #include <QLabel>
 #include <QPushButton>
+#include <QSlider>
 #include <QThread>
 #include <QWidget>
 
@@ -35,21 +36,23 @@ public:
 
 public slots:
     void Initialize();
-    void Play();
+    void Play(std::chrono::microseconds from = std::chrono::microseconds::zero());
     void Stop();
 
 signals:
     void LoadFinished(QString error);
     void StateChanged(QAudio::State state);
-    void TimeUpdated(std::chrono::milliseconds ms);
+    void TimeUpdated(std::chrono::microseconds current, std::chrono::microseconds length);
 
 private slots:
     void OnNotify();
+    void OnStateChanged(QAudio::State state);
 
 private:
     std::unique_ptr<QIODevice> m_io_device;
     std::unique_ptr<AudioFile> m_audio_file;
     std::unique_ptr<QAudioOutput> m_audio_output;
+    std::chrono::microseconds m_start_offset;
 };
 
 class PlaybackWidget : public QWidget
@@ -63,17 +66,20 @@ public:
     void LoadAudio(std::unique_ptr<QIODevice> io_device);  // Can be nullptr
 
 signals:
-    void TimeUpdated(std::chrono::milliseconds ms);
+    void TimeUpdated(std::chrono::milliseconds current);
 
 private slots:
     void OnLoadResult(QString result);
     void OnPlayButtonClicked();
+    void OnTimeSliderMoved(int value);
+    void OnTimeSliderReleased();
     void OnStateChanged(QAudio::State state);
-    void UpdateTime(std::chrono::milliseconds ms);
+    void UpdateTime(std::chrono::microseconds current, std::chrono::microseconds length);
 
 private:
     QPushButton* m_play_button;
     QLabel* m_time_label;
+    QSlider* m_time_slider;
 
     AudioOutputWorker* m_worker = nullptr;
     QThread m_thread;
@@ -81,4 +87,4 @@ private:
     QAudio::State m_state;
 };
 
-Q_DECLARE_METATYPE(std::chrono::milliseconds);
+Q_DECLARE_METATYPE(std::chrono::microseconds);


### PR DESCRIPTION
As part of that, shows the length of the audio. Changed to use microseconds more widely. Fixed playing audio after song finished. Monospace font for playback position since not all fonts have monospace digits.