### PR TITLE
macOS proxy icon support

### DIFF
--- a/hibikase/MainWindow.cpp
+++ b/hibikase/MainWindow.cpp
@@ -160,6 +160,7 @@ void MainWindow::UpdateWindowTitle()
         file_name.append(QChar('*'));
     file_name.append(m_save_path.isEmpty() ? "Untitled" : QFileInfo(m_save_path).fileName());
     setWindowTitle(QStringLiteral("%1 - Hibikase").arg(file_name));
+    setWindowFilePath(m_save_path); // macOS proxy icon support
 }
 
 void MainWindow::LoadAudio()


### PR DESCRIPTION
This means macOS will show a little file icon in the window title bar, which can be dragged into other applications, e.g. the terminal to get the file path.