### PR TITLE
Change placeholder time and timecode

### DIFF
--- a/hibikase/KaraokeData/Song.h
+++ b/hibikase/KaraokeData/Song.h
@@ -44,11 +44,10 @@ namespace KaraokeData
 
 typedef std::chrono::duration<int32_t, std::centi> Centiseconds;
 
-static constexpr Centiseconds PLACEHOLDER_TIME = Centiseconds(100 * 60 * 100 - 1);
+static constexpr Centiseconds PLACEHOLDER_TIME = Centiseconds(-1);
 
-// Largest and smallest times safely representable given how Hibikase uses the
-// Soramimi [mm:ss:cc] format
-static constexpr Centiseconds MAXIMUM_TIME = PLACEHOLDER_TIME - Centiseconds(1);
+// Largest and smallest times safely representable in Soramimi [mm:ss:cc] format
+static constexpr Centiseconds MAXIMUM_TIME = Centiseconds(100 * 60 * 100 - 1);
 static constexpr Centiseconds MINIMUM_TIME = Centiseconds(0);
 
 class Syllable : public QObject


### PR DESCRIPTION
`[99:59:59]` is replaced with `[__:__:__]` (time = -1). Unlike the former, it is not a valid time, and it also has a distinctly different shape to the eye, which makes the raw view easier to read.