### PR TITLE
Handle all kinds of speed slider moves, not just dragging

### DIFF
--- a/hibikase/PlaybackWidget.cpp
+++ b/hibikase/PlaybackWidget.cpp
@@ -68,7 +68,7 @@ PlaybackWidget::PlaybackWidget(QWidget* parent) : QWidget(parent)
     connect(m_stop_button, &QPushButton::clicked, this, &PlaybackWidget::OnStopButtonClicked);
     connect(m_time_slider, &QSlider::sliderMoved, this, &PlaybackWidget::OnTimeSliderMoved);
     connect(m_time_slider, &QSlider::sliderReleased, this, &PlaybackWidget::OnTimeSliderReleased);
-    connect(m_speed_slider, &QSlider::sliderMoved, this, &PlaybackWidget::OnSpeedSliderMoved);
+    connect(m_speed_slider, &QSlider::valueChanged, this, &PlaybackWidget::OnSpeedSliderUpdated);
     LoadAudio(nullptr);
 
     m_thread.start();
@@ -171,7 +171,7 @@ void PlaybackWidget::OnTimeSliderReleased()
     QMetaObject::invokeMethod(m_worker, "Seek", Q_ARG(std::chrono::microseconds, new_pos));
 }
 
-void PlaybackWidget::OnSpeedSliderMoved(int value)
+void PlaybackWidget::OnSpeedSliderUpdated(int value)
 {
     UpdateSpeedLabel(value);
 

--- a/hibikase/PlaybackWidget.h
+++ b/hibikase/PlaybackWidget.h
@@ -44,7 +44,7 @@ private slots:
     void OnStopButtonClicked();
     void OnTimeSliderMoved(int value);
     void OnTimeSliderReleased();
-    void OnSpeedSliderMoved(int value);
+    void OnSpeedSliderUpdated(int value);
     void OnStateChanged(QAudio::State state);
     void UpdateTime(std::chrono::microseconds current, std::chrono::microseconds length);
 


### PR DESCRIPTION
On some OSes, a slider can be moved without dragging it. Unlike the time slider, we don't want special behaviour depending on how the speed slider was moved, so we should use the generic event type.