### PR TITLE
Use "*.txt" filter for Open and Save dialog boxes

### DIFF
--- a/hibikase/MainWindow.cpp
+++ b/hibikase/MainWindow.cpp
@@ -107,7 +107,7 @@ void MainWindow::on_actionOpen_triggered()
     if (!SaveUnsavedChanges())
         return;
 
-    QString load_path = QFileDialog::getOpenFileName(this);
+    QString load_path = QFileDialog::getOpenFileName(this, "Open lyrics file", QString(), FILTER);
     if (load_path.isEmpty())
         return;
 
@@ -196,7 +196,7 @@ bool MainWindow::Save(QString path)
 
 bool MainWindow::SaveAs()
 {
-    const QString save_path = QFileDialog::getSaveFileName(this);
+    const QString save_path = QFileDialog::getSaveFileName(this, "Save lyrics file", QString(), FILTER);
     if (save_path.isEmpty())
         return false;
 

--- a/hibikase/MainWindow.h
+++ b/hibikase/MainWindow.h
@@ -49,6 +49,8 @@ private slots:
     void OnSongModified();
 
 private:
+    const QString FILTER = QStringLiteral("Soramimi Lyrics (*.txt);;All Files (*.*)");
+
     void UpdateWindowTitle();
     void LoadAudio();
     bool Save(QString path);


### PR DESCRIPTION
Fixes #21 (prevents accidentally opening audio files as text) and also ensures saved files will have a .txt extension if the user didn't specify one.